### PR TITLE
Replace range of years (2018-2020) with year of first publication (2018) in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Tom G.
+Copyright (c) 2018 Tom G.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Only the year of first publication is required: https://en.m.wikipedia.org/wiki/Copyright_notice#Form_of_notice_for_visually_perceptible_copies, and updating range of years every year is not worth It.

By the way, did you really create this app in 2018? The inital commit of this repo was in 2020